### PR TITLE
[DefaultHandlerExceptionResolver 실습] 형식에 맞지 않는 파라미터의 요청 : 내부적으로 500 -> 400 처리

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/member/MemberController.java
+++ b/src/main/java/com/hcommerce/heecommerce/member/MemberController.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -42,6 +43,11 @@ public class MemberController {
         } else {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다.", new IllegalArgumentException());
         }
+    }
+
+    @GetMapping("/api/default-handler-ex")
+    public Integer defaultException(@RequestParam Integer data) {
+        return data;
     }
 
     @Data


### PR DESCRIPTION
# 실습
1. 정상 요청
<img width="1259" alt="스크린샷 2023-04-30 오후 7 39 14" src="https://user-images.githubusercontent.com/60481383/235348631-b286b1cb-6e7b-48c6-828c-e5fd8686bef2.png">
2. 형식에 맞지 않는 파라미터로 요청
<img width="1259" alt="스크린샷 2023-04-30 오후 7 39 03" src="https://user-images.githubusercontent.com/60481383/235348625-8d3c7f8a-a359-45be-80a6-a0811f263c10.png">
