### PR TITLE
@RestControllerAdvice 사용한 예외 처리 vs @RestControllerAdvice 사용하지 않은 예외 처리

### DIFF
--- a/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderController.java
@@ -1,8 +1,8 @@
 package com.hcommerce.heecommerce.order;
 
-import com.hcommerce.heecommerce.common.dto.CommandSuccessResponseDto;
+import com.hcommerce.heecommerce.common.dto.ResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,11 +20,18 @@ public class OrderController {
     }
 
     @PatchMapping("/admin/orders/{orderUuid}/order-receipt-complete")
-    public ResponseEntity<CommandSuccessResponseDto> completeOrderReceipt(@PathVariable("orderUuid") UUID orderUuid) {
+    public ResponseDto completeOrderReceipt(@PathVariable("orderUuid") UUID orderUuid) {
 
-        orderService.completeOrderReceipt(orderUuid);
+        try {
+            orderService.completeOrderReceipt(orderUuid);
+        } catch (OrderOverStockException ex) {
+            return new ResponseDto(HttpStatus.CONFLICT.name(), ex.getMessage());
+        } catch (OrderNotFoundException ex) {
+            return new ResponseDto(HttpStatus.NOT_FOUND.name(), ex.getMessage());
+        } catch (Exception ex) {
+            return new ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.name(), "내부 서버 오류가 발생했습니다.");
+        }
 
-        return ResponseEntity.ok()
-                .body(new CommandSuccessResponseDto("주문 접수 완료가 처리되었습니다."));
+        return new ResponseDto(HttpStatus.OK.name(), "주문 접수 완료가 처리되었습니다.");
     }
 }

--- a/src/main/java/com/hcommerce/heecommerce/order/OrderControllerAdvice.java
+++ b/src/main/java/com/hcommerce/heecommerce/order/OrderControllerAdvice.java
@@ -5,10 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
-@RestControllerAdvice
+//@RestControllerAdvice
 public class OrderControllerAdvice {
 
     @ResponseStatus(HttpStatus.NOT_FOUND)


### PR DESCRIPTION
# @RestControllerAdvice에 적용된 패턴
- AOP 기술

# @RestControllerAdvice 사용하여 예외 처리했을 때의 장점
- 관심사 분리의 장점과 동일하다. -> 비즈니스 로직에 집중할 수 있다.

# @RestControllerAdvice 사용하지 않았을 때의 단점
- 비즈니스 로직과 그렇지 않은 로직이 섞여 있어 코드가 지저분해진다.
